### PR TITLE
Use accept-language instead of accept_language

### DIFF
--- a/nominatim_reverse.go
+++ b/nominatim_reverse.go
@@ -64,7 +64,7 @@ func (r *ReverseQuery) buildQuery() (string, error) {
 	s := server
 	s = s + "/reverse?format=json"
 	if r.AcceptLanguage != "" {
-		s = s + "&accept_language=" + r.AcceptLanguage
+		s = s + "&accept-language=" + r.AcceptLanguage
 	}
 	if r.OsmType != "" {
 		if r.OsmType != "N" && r.OsmType != "W" && r.OsmType != "R" {

--- a/nominatim_search.go
+++ b/nominatim_search.go
@@ -90,7 +90,7 @@ func (q *SearchQuery) buildQuery() (string, error) {
 		s += "&json_callback=" + string(cb)
 	}
 	if q.AcceptLanguage != "" {
-		s += "&accept_language=" + url.QueryEscape(q.AcceptLanguage)
+		s += "&accept-language=" + url.QueryEscape(q.AcceptLanguage)
 	}
 	if q.Q != "" {
 		s += "&q=" + url.QueryEscape(q.Q)


### PR DESCRIPTION
Sending accept-language, Nominatim accepts the language request:

```
curl -s "https://nominatim.openstreetmap.org/search?format=json&accept-language=en-US&q=barcelona&addressdetails=1&limit=1"|python -mjson.tool
[
    {
        "address": {
            "city": "Barcelona",
            "country": "Spain",
            "country_code": "es",
            "county": "Barcelon\u00e8s",
            "state": "Catalonia"
        },
```

Same request, lang ignored when using accept_language:

```
curl -s "https://nominatim.openstreetmap.org/search?format=json&accept_language=en-US&q=barcelona&addressdetails=1&limit=1"|python -mjson.tool
[
    {
        "address": {
            "city": "Barcelona",
            "country": "Espa\u00f1a",
            "country_code": "es",
            "county": "Barcelon\u00e8s",
            "state": "Catalunya"
        },

```